### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,22 +5,22 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "weekly"
-    target-branch: "develop"
+      interval: "daily"
+    target-branch: "master"
     versioning-strategy: "increase"
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
+      prefix: "chore"
+      include_scope: true
 
   - package-ecosystem: "npm"
     directory: "/server"
     schedule:
-      interval: "weekly"
-    target-branch: "develop"
+      interval: "daily"
+    target-branch: "master"
     versioning-strategy: "increase"
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
+      prefix: "chore"
+      include_scope: true


### PR DESCRIPTION
あんまり develop で分ける恩恵を現時点では得られなさそうなので master へ `chore(deps): ...` でやります。