### PR TITLE
chore(terraform): upgrade terraform to 0.13

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,7 +25,7 @@ jobs:
       - name: terraform setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.24
+          terraform_version: 0.13.6
       - id: init
         run: terraform init
         working-directory: server/terraform
@@ -37,7 +37,7 @@ jobs:
         working-directory: server/terraform
         if: github.event_name == 'pull_request'
       - uses: actions/github-script@v3
-        if: <
+        if: >
           github.event_name == 'pull_request'
           && github.actor != 'dependabot[bot]'
           && github.actor != 'dependabot-preview[bot]'


### PR DESCRIPTION
sshcommand-commandが古いtfでは使えない、先にアップグレードが必要そう、この PR のチェックでアップグレードを走らせる。